### PR TITLE
Lower label's case before processing

### DIFF
--- a/pkg/handlers/parser/parser.go
+++ b/pkg/handlers/parser/parser.go
@@ -37,7 +37,7 @@ func NewParser(fqdn, zone string) *Parser {
 		ripReq = fqdn[:len(fqdn)-len(zone)-1]
 	}
 
-	labels := strings.Split(ripReq, ".")
+	labels := strings.Split(strings.ToLower(ripReq), ".")
 	slices.StringsReverse(labels)
 	return &Parser{
 		cur:      0,


### PR DESCRIPTION
E.g. Google Public DNS randomizes case in the requests it sends. For example, `8ba299a7.v4-ttl-5s.8ba299a8.v4-cnt-5.loop.example.com.` may become `8BA299a7.V4-ttl-5s.8BA299A8.V4-cNt-5.lOOP.ExAmPLE.cOm.`, (taken from the real request Google Public DNS has sent to me).

This commits makes so RIP can successfully parse requests regardless of the case.